### PR TITLE
Change access to `iworks_omnibus_integration_woocommerce::get_price()`

### DIFF
--- a/includes/iworks/class-iworks-omnibus.php
+++ b/includes/iworks/class-iworks-omnibus.php
@@ -75,6 +75,10 @@ class iworks_omnibus {
 		add_action( 'wp_ajax_iworks_omnibus_migrate_v3', array( $this, 'migration_v3_action_wp_ajax_iworks_omnibus_migrate_v3' ) );
 	}
 
+	public function get_object() {
+	    return $this->objects;
+	}
+
 	public function action_plugins_loaded() {
 		$dir = dirname( __FILE__ ) . '/omnibus';
 		/**

--- a/includes/iworks/omnibus/integration/class-iworks-omnibus-integration-woocommerce.php
+++ b/includes/iworks/omnibus/integration/class-iworks-omnibus-integration-woocommerce.php
@@ -824,7 +824,7 @@ class iworks_omnibus_integration_woocommerce extends iworks_omnibus_integration 
 	 *
 	 * @since 2.0.2
 	 */
-	private function get_price( $product ) {
+	public function get_price( $product ) {
 		/**
 		 * check method_exists
 		 *

--- a/includes/iworks/omnibus/integration/class-iworks-omnibus-integration-woocommerce.php
+++ b/includes/iworks/omnibus/integration/class-iworks-omnibus-integration-woocommerce.php
@@ -468,7 +468,7 @@ class iworks_omnibus_integration_woocommerce extends iworks_omnibus_integration 
 	/**
 	 * get lowest price
 	 */
-	private function get_lowest_price( $product ) {
+	public function get_lowest_price( $product ) {
 		/**
 		 * get price
 		 *

--- a/omnibus.php
+++ b/omnibus.php
@@ -45,7 +45,7 @@ if ( ! class_exists( 'iworks_omnibus' ) ) {
  */
 load_plugin_textdomain( 'omnibus', false, plugin_basename( dirname( __FILE__ ) ) . '/languages' );
 
-new iworks_omnibus();
+$GLOBALS['iworks_omnibus'] = new iworks_omnibus();
 
 /**
  * install & uninstall


### PR DESCRIPTION
## Change `iworks_omnibus_integration_woocommerce::get_price()` from a private method to a public one
### Reasoning
There are many cases where we would only need the price, and the only way to get it right now is through parsing the result string of the `omnibus_price_message` shortcode. This however scales poorly with the amount of products shown - each product is passed to the shortcode by ID and then a WP_Product is created for each call. Allowing public use of this method would be beneficial for such use case.